### PR TITLE
Fix bug with UK_Pac facilities being owned by UK_Europe

### DIFF
--- a/map/games/ww2global40.xml
+++ b/map/games/ww2global40.xml
@@ -4582,9 +4582,9 @@
       <unitPlacement unitType="infantry" territory="Hunan" quantity="1" owner="Chinese"/>
       <unitPlacement unitType="infantry" territory="Yunnan" quantity="3" owner="Chinese"/>
       <unitPlacement unitType="infantry" territory="Kwangtung" quantity="2" owner="British"/>
-      <unitPlacement unitType="harbour" territory="Kwangtung" quantity="1" owner="British"/>
+      <unitPlacement unitType="harbour" territory="Kwangtung" quantity="1" owner="UK_Pacific"/>
       <unitPlacement unitType="infantry" territory="Malaya" quantity="4" owner="British"/>
-      <unitPlacement unitType="harbour" territory="Malaya" quantity="1" owner="British"/>
+      <unitPlacement unitType="harbour" territory="Malaya" quantity="1" owner="UK_Pacific"/>
       <unitPlacement unitType="infantry" territory="Burma" quantity="1" owner="British"/>
       <unitPlacement unitType="fighter" territory="Burma" quantity="1" owner="British"/>
       <unitPlacement unitType="infantry" territory="India" quantity="4" owner="British"/>
@@ -4592,8 +4592,8 @@
       <unitPlacement unitType="fighter" territory="India" quantity="3" owner="British"/>
       <unitPlacement unitType="tactical_bomber" territory="India" quantity="1" owner="British"/>
       <unitPlacement unitType="aaGun" territory="India" quantity="1" owner="British"/>
-      <unitPlacement unitType="airfield" territory="India" quantity="1" owner="British"/>
-      <unitPlacement unitType="harbour" territory="India" quantity="1" owner="British"/>
+      <unitPlacement unitType="airfield" territory="India" quantity="1" owner="UK_Pacific"/>
+      <unitPlacement unitType="harbour" territory="India" quantity="1" owner="UK_Pacific"/>
       <unitPlacement unitType="factory_major" territory="India" quantity="1" owner="UK_Pacific"/>
       <unitPlacement unitType="destroyer" territory="39 Sea Zone" quantity="1" owner="British"/>
       <unitPlacement unitType="cruiser" territory="39 Sea Zone" quantity="1" owner="British"/>

--- a/map/games/ww2global40_2nd_edition.xml
+++ b/map/games/ww2global40_2nd_edition.xml
@@ -5704,9 +5704,9 @@
       <unitPlacement unitType="battleship" territory="111 Sea Zone" quantity="1" owner="British"/>
       <unitPlacement unitType="cruiser" territory="111 Sea Zone" quantity="1" owner="British"/>
       <unitPlacement unitType="infantry" territory="Kwangtung" quantity="2" owner="British"/>
-      <unitPlacement unitType="harbour" territory="Kwangtung" quantity="1" owner="British"/>
+      <unitPlacement unitType="harbour" territory="Kwangtung" quantity="1" owner="UK_Pacific"/>
       <unitPlacement unitType="infantry" territory="Malaya" quantity="3" owner="British"/>
-      <unitPlacement unitType="harbour" territory="Malaya" quantity="1" owner="British"/>
+      <unitPlacement unitType="harbour" territory="Malaya" quantity="1" owner="UK_Pacific"/>
       <unitPlacement unitType="infantry" territory="Burma" quantity="2" owner="British"/>
       <unitPlacement unitType="fighter" territory="Burma" quantity="1" owner="British"/>
       <unitPlacement unitType="infantry" territory="India" quantity="6" owner="British"/>
@@ -5714,8 +5714,8 @@
       <unitPlacement unitType="aaGun" territory="India" quantity="3" owner="British"/>
       <unitPlacement unitType="fighter" territory="India" quantity="1" owner="British"/>
       <unitPlacement unitType="tactical_bomber" territory="India" quantity="1" owner="British"/>
-      <unitPlacement unitType="airfield" territory="India" quantity="1" owner="British"/>
-      <unitPlacement unitType="harbour" territory="India" quantity="1" owner="British"/>
+      <unitPlacement unitType="airfield" territory="India" quantity="1" owner="UK_Pacific"/>
+      <unitPlacement unitType="harbour" territory="India" quantity="1" owner="UK_Pacific"/>
       <unitPlacement unitType="factory_major" territory="India" quantity="1" owner="UK_Pacific"/>
       <unitPlacement unitType="battleship" territory="37 Sea Zone" quantity="1" owner="British"/>
       <unitPlacement unitType="destroyer" territory="39 Sea Zone" quantity="1" owner="British"/>
@@ -6403,7 +6403,6 @@ You may also need to use edit mode to correct things listed below.<br>
 <br>
 <br><b>Rules specific to 1940 the engine does not do, but you must follow:</b>
 <br>* (EM) You may ask for permission during your turn to move through a canal owned by a power you are not yet at war with (use edit mode to move them).
-<br>* (EM) India (UK Pacific) must pay for repairing any damaged facilities on the pacific half of the board (instead of London paying) (use edit mode to subtrack the PUs from India and give back to London).
 <br>* (CL) TripleA does not keep track of which neutral territories have been previously attacked (use comment log to keep track of this instead).
 <br>* (PE) You are not allowed to blitz or move any units through Friendly Neutrals, including the same turn they are captured, unless they have been previously attacked.
 <br>* (PE) You may not land air units in Friendly Neutrals, including the same turn they are captured, unless they have been previously attacked.

--- a/map/games/ww2global40_alpha3.xml
+++ b/map/games/ww2global40_alpha3.xml
@@ -5662,9 +5662,9 @@
       <unitPlacement unitType="battleship" territory="111 Sea Zone" quantity="1" owner="British"/>
       <unitPlacement unitType="cruiser" territory="111 Sea Zone" quantity="1" owner="British"/>
       <unitPlacement unitType="infantry" territory="Kwangtung" quantity="2" owner="British"/>
-      <unitPlacement unitType="harbour" territory="Kwangtung" quantity="1" owner="British"/>
+      <unitPlacement unitType="harbour" territory="Kwangtung" quantity="1" owner="UK_Pacific"/>
       <unitPlacement unitType="infantry" territory="Malaya" quantity="3" owner="British"/>
-      <unitPlacement unitType="harbour" territory="Malaya" quantity="1" owner="British"/>
+      <unitPlacement unitType="harbour" territory="Malaya" quantity="1" owner="UK_Pacific"/>
       <unitPlacement unitType="infantry" territory="Burma" quantity="2" owner="British"/>
       <unitPlacement unitType="fighter" territory="Burma" quantity="1" owner="British"/>
       <unitPlacement unitType="infantry" territory="India" quantity="6" owner="British"/>
@@ -5672,8 +5672,8 @@
       <unitPlacement unitType="aaGun" territory="India" quantity="3" owner="British"/>
       <unitPlacement unitType="fighter" territory="India" quantity="1" owner="British"/>
       <unitPlacement unitType="tactical_bomber" territory="India" quantity="1" owner="British"/>
-      <unitPlacement unitType="airfield" territory="India" quantity="1" owner="British"/>
-      <unitPlacement unitType="harbour" territory="India" quantity="1" owner="British"/>
+      <unitPlacement unitType="airfield" territory="India" quantity="1" owner="UK_Pacific"/>
+      <unitPlacement unitType="harbour" territory="India" quantity="1" owner="UK_Pacific"/>
       <unitPlacement unitType="factory_major" territory="India" quantity="1" owner="UK_Pacific"/>
       <unitPlacement unitType="battleship" territory="37 Sea Zone" quantity="1" owner="British"/>
       <unitPlacement unitType="destroyer" territory="39 Sea Zone" quantity="1" owner="British"/>

--- a/map/games/ww2global42_2nd_edition.xml
+++ b/map/games/ww2global42_2nd_edition.xml
@@ -5731,8 +5731,8 @@
       <unitPlacement unitType="aaGun" territory="India" quantity="2" owner="British"/>
       <unitPlacement unitType="fighter" territory="India" quantity="1" owner="British"/>
       <unitPlacement unitType="tactical_bomber" territory="India" quantity="1" owner="British"/>
-      <unitPlacement unitType="airfield" territory="India" quantity="1" owner="British"/>
-      <unitPlacement unitType="harbour" territory="India" quantity="1" owner="British"/>
+      <unitPlacement unitType="airfield" territory="India" quantity="1" owner="UK_Pacific"/>
+      <unitPlacement unitType="harbour" territory="India" quantity="1" owner="UK_Pacific"/>
       <unitPlacement unitType="factory_major" territory="India" quantity="1" owner="UK_Pacific"/>
       <unitPlacement unitType="carrier" territory="39 Sea Zone" quantity="1" owner="British"/>
       <unitPlacement unitType="fighter" territory="39 Sea Zone" quantity="1" owner="British"/>
@@ -6423,7 +6423,6 @@ You may also need to use edit mode to correct things listed below.<br>
 <br>
 <br><b>Rules specific to 1940 the engine does not do, but you must follow:</b>
 <br>* (EM) You may ask for permission during your turn to move through a canal owned by a power you are not yet at war with (use edit mode to move them).
-<br>* (EM) India (UK Pacific) must pay for repairing any damaged facilities on the pacific half of the board (instead of London paying) (use edit mode to subtrack the PUs from India and give back to London).
 <br>* (CL) TripleA does not keep track of which neutral territories have been previously attacked (use comment log to keep track of this instead).
 <br>* (PE) You are not allowed to blitz or move any units through Friendly Neutrals, including the same turn they are captured, unless they have been previously attacked.
 <br>* (PE) You may not land air units in Friendly Neutrals, including the same turn they are captured, unless they have been previously attacked.


### PR DESCRIPTION
This Pull Request fixes a bug in the XML which sees starting airfields and harbours in the Pacific map owned by the European economy. This causes the funds for repairs to be wrongly drawn from the European economy.

There is something in the notes about this is some maps which I've also removed in this commit.